### PR TITLE
fix(i18n): use kebab-case for text domain in load_textdomain()

### DIFF
--- a/src/traits/PluginTrait.php
+++ b/src/traits/PluginTrait.php
@@ -650,7 +650,8 @@ trait PluginTrait {
 	 * @see https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/
 	 */
 	public function load_textdomain(): void {
-		\load_plugin_textdomain(self::$kebab, false, self::$dir . '/languages');
+		$plugin_rel_path = \dirname(\plugin_basename(self::$plugin_entry_path)) . '/languages';
+		\load_plugin_textdomain(self::$kebab, false, $plugin_rel_path);
 	}
 
 	/**

--- a/src/traits/PluginTrait.php
+++ b/src/traits/PluginTrait.php
@@ -641,9 +641,16 @@ trait PluginTrait {
 
 	/**
 	 * Load textdomain i18n
+	 *
+	 * Text domain must use kebab-case (dashes), per WordPress Plugin Handbook
+	 * and to match the `Text Domain:` header that plugins declare in their main file.
+	 * Using snake_case here would silently fail because every gettext call
+	 * (`__('...', 'plugin-slug')`) targets the kebab domain registered in the header.
+	 *
+	 * @see https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/
 	 */
 	public function load_textdomain(): void {
-		\load_plugin_textdomain(self::$snake, false, self::$dir . '/languages');
+		\load_plugin_textdomain(self::$kebab, false, self::$dir . '/languages');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`PluginTrait::load_textdomain()` 把 text domain 寫成 `self::$snake`（底線形式），但 WordPress plugin 的 `Text Domain:` header 與 plugin slug 必須是 kebab-case（連字號）。結果是：**所有使用此 trait 的 plugin 都在 silently 載入失敗的翻譯**——`.mo` 檔 `languages/{snake}-{locale}.mo` 從未存在，而每個 `__('...', 'plugin-slug')` 呼叫指向的是 trait 從未載入過的 kebab domain。

## 根本原因

```php
// L646 (before)
\load_plugin_textdomain(self::$snake, false, self::$dir . '/languages');
//                       ^^^^^^^^^^^^ 'power_course'（底線）

// plugin.php header
* Text Domain: power-course   ← gettext 實際查找的 domain（連字號）
```

兩者完全不對應，gettext 查找永遠失敗。

## 為什麼改 `$kebab` 才對

1. **WordPress Plugin Handbook 明確規範**：[text domain must match the plugin slug, and the slug must use dashes](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/)
2. **與 plugin header 一致**：plugin.php 的 `Text Domain:` 一律是 kebab，trait 的 `load_textdomain()` 應該對齊
3. **Trait 本身已主流使用 `$kebab`**：grep 顯示 trait 內 9 處用 `self::$kebab` 識別 plugin（required-plugin 檢查、license auth、TGMPA 設定、admin notices），只有 L646 與 L289 用 `self::$snake`。其中 L289 (`{$snake}_settings` option key) 是正確使用——option key 慣例就是 snake_case；L646 才是寫錯的特例。
4. **整個生態系工具預設都是 kebab**：`wp i18n make-pot`、Poedit、Loco Translate、GlotPress、translate.wordpress.org Language Pack 都根據 plugin header 的 `Text Domain` 識別，預期 kebab。選 snake 等於每個工具都要手動指定 domain。

## Fix

```diff
- \load_plugin_textdomain(self::$snake, false, self::$dir . '/languages');
+ \load_plugin_textdomain(self::$kebab, false, self::$dir . '/languages');
```

外加一段 docblock 說明為什麼必須是 kebab，避免下次又被改回 snake。

## Breaking Change 評估

技術上是 breaking change：如果有 plugin 已經針對舊的 snake 行為產出 `.mo`（例如有人已經建好 `languages/power_course-en_US.mo`），這個修改後它們會失效。

實際上**幾乎不可能有人這樣做**，因為：
- plugin header 是 kebab，所有 gettext 呼叫都指向 kebab domain
- 即使 trait 載入了 snake domain 的 `.mo`，runtime 的 `__('...', 'plugin-slug')` 也查不到，因為它們去 query 的是 kebab domain
- 換句話說：**舊的 snake `.mo` 就算存在也沒人用**

所以這個 fix 不會造成任何使用者實際感受到的 regression，只會讓**原本壞掉但沒人發現的翻譯系統開始 work**。

## Test plan

- [x] `php -l src/traits/PluginTrait.php` 通過
- [ ] 在 power-course 專案實測：移除 plugin.php 裡為了繞過此 bug 而加的 `init` hook，確認 PluginTrait 自己就能正確載入 `languages/power-course-{locale}.mo`
- [ ] 跑一次該 plugin 的 `composer test` / PHPUnit（如果有）
- [ ] 升級 vendor 後檢查其他用 PluginTrait 的 plugin（powerhouse 等）有沒有任何 i18n 路徑依賴 `power_course` 那種底線形式（理論上沒有）

## 相關背景

這個 bug 是在為 Power Course 導入 i18n 基礎設施時發現的。當時為了不動 vendor，先在 plugin.php 加了一個 `init` hook 補載 `power-course` 連字號 domain。這個 PR 從根本修掉之後，該繞道可以移除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)